### PR TITLE
initial config api

### DIFF
--- a/src/Config.ts
+++ b/src/Config.ts
@@ -1,0 +1,42 @@
+const DEFAULT_GROUP_NAME = 'dev';
+const DEFAULT_GROUP_PASSWORD = 'dev-pass';
+
+export class GroupConfig {
+    name: string = DEFAULT_GROUP_NAME;
+    password: string = DEFAULT_GROUP_PASSWORD;
+}
+
+export class SocketOptions {
+    //TO-DO
+}
+
+export class ClientNetworkConfig {
+    addresses: string[];
+    connectionAttemptLimit: number = 2;
+    connectionAttemptPeriod: number = 3000;
+    connectionTimeout: number = 5000;
+    redoOperation: boolean = false;
+    smartRouting: boolean = false;
+    socketOptions: SocketOptions = new SocketOptions();
+}
+
+export class SerializationConfig {
+    //TO-DO when implementing serialization
+}
+
+export class GlobalSerializerConfig {
+    //TO-DO when implementing serialization
+}
+
+export class ListenerConfig {
+    //TO-DO
+}
+
+export class ClientConfig {
+    instanceName: string;
+    properties = {};
+    groupConfig: GroupConfig = new GroupConfig();
+    networkConfig: ClientNetworkConfig = new ClientNetworkConfig();
+    listenerConfigs: ListenerConfig[];
+    serializationConfig: SerializationConfig = new SerializationConfig();
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
   ],
   "files": [
     "src/BitsUtil.ts",
-    "src/ClientMessage.ts"
+    "src/ClientMessage.ts",
+    "src/Config.ts"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
Order as 
```
export class ClientConfig { //
export class NetworkConfig { //
```
Causes use before declaration error in compiled JS code at `jshint` stage although I think it is not an issue in TypeScript. Anyway I re-ordered the classes so that it passes without an error now.