### PR TITLE
heartbeat service

### DIFF
--- a/src/Config.ts
+++ b/src/Config.ts
@@ -41,7 +41,10 @@ export class ListenerConfig {
 
 export class ClientConfig {
     instanceName: string;
-    properties = {};
+    properties: any = {
+        'hazelcast.client.heartbeat.interval': 5000,
+        'hazelcast.client.heartbeat.timeout': 60000
+    };
     groupConfig: GroupConfig = new GroupConfig();
     networkConfig: ClientNetworkConfig = new ClientNetworkConfig();
     listenerConfigs: ListenerConfig[];

--- a/src/ConnectionHeartbeatListener.ts
+++ b/src/ConnectionHeartbeatListener.ts
@@ -1,0 +1,5 @@
+import ClientConnection = require('./invocation/ClientConnection');
+export interface ConnectionHeartbeatListener {
+    onHeartbeatRestored?: (connection?: ClientConnection) => void;
+    onHeartbeatStopped?: (connection?: ClientConnection) => void;
+}

--- a/src/ConnectionListener.ts
+++ b/src/ConnectionListener.ts
@@ -1,0 +1,5 @@
+import ClientConnection = require('./invocation/ClientConnection');
+export interface ConnectionListener {
+    onConnectionOpened?: (connection: ClientConnection) => void;
+    onConnectionClosed?: (connection: ClientConnection) => void;
+}

--- a/src/HazelcastClient.ts
+++ b/src/HazelcastClient.ts
@@ -8,6 +8,7 @@ import {IMap} from './IMap';
 import {JsonSerializationService} from './serialization/SerializationService';
 import PartitionService = require('./PartitionService');
 import ClusterService = require('./invocation/ClusterService');
+import Heartbeat = require('./Heartbeat');
 
 class HazelcastClient {
 
@@ -18,6 +19,7 @@ class HazelcastClient {
     private partitionService: PartitionService;
     private clusterService: ClusterService;
     private proxyManager: ProxyManager;
+    private heartbeat: Heartbeat;
 
     public static newHazelcastClient(config?: ClientConfig): Q.Promise<HazelcastClient> {
         var client: HazelcastClient = new HazelcastClient(config);
@@ -35,16 +37,22 @@ class HazelcastClient {
         this.partitionService = new PartitionService(this);
         this.connectionManager = new ClientConnectionManager(this);
         this.clusterService = new ClusterService(this);
+        this.heartbeat = new Heartbeat(this);
     }
 
     private init(): Q.Promise<HazelcastClient> {
         var deferred = Q.defer<HazelcastClient>();
 
-        this.clusterService.start().then(() => {
-            return this.partitionService.initialize();
-        }).then(() => {
-            deferred.resolve(this);
-        }).catch((e) => {
+        this.clusterService.start()
+            .then(() => {
+                return this.partitionService.initialize();
+            })
+            .then(() => {
+                return this.heartbeat.start();
+            })
+            .then(() => {
+                deferred.resolve(this);
+            }).catch((e) => {
             deferred.reject(e);
         });
 

--- a/src/HazelcastClient.ts
+++ b/src/HazelcastClient.ts
@@ -90,6 +90,10 @@ class HazelcastClient {
     public getClusterService(): ClusterService {
         return this.clusterService;
     }
+
+    getHeartbeat(): Heartbeat {
+        return this.heartbeat;
+    }
 }
 
 export = HazelcastClient;

--- a/src/Heartbeat.ts
+++ b/src/Heartbeat.ts
@@ -1,0 +1,68 @@
+import {ClientPingCodec} from './codec/ClientPingCodec';
+import HazelcastClient = require('./HazelcastClient');
+import ClientConnection = require('./invocation/ClientConnection');
+
+var PROPERTY_HEARTBEAT_INTERVAL: string = 'hazelcast.client.heartbeat.interval';
+var PROPERTY_HEARTBEAT_TIMEOUT: string = 'hazelcast.client.heartbeat.timeout';
+
+class Heartbeat {
+
+    private client: HazelcastClient;
+    private heartbeatTimeout: number;
+    private heartbeatInterval: number;
+
+    //Actually it is a NodeJS.Timer. Another typing file that comes with a module we use causes TSD to see
+    //return type of setTimeout as number. Because of this we defined timer property as `any` type.
+    private timer: any;
+
+    constructor(client: HazelcastClient) {
+        this.client = client;
+        this.heartbeatInterval = this.client.getConfig().properties[PROPERTY_HEARTBEAT_INTERVAL];
+        this.heartbeatTimeout = this.client.getConfig().properties[PROPERTY_HEARTBEAT_TIMEOUT];
+    }
+
+    start() {
+        this.timer = setTimeout(this.heartbeatFunction.bind(this), this.heartbeatInterval);
+    }
+
+    cancel() {
+        clearTimeout(this.timer);
+    }
+
+    private heartbeatFunction() {
+        var estConnections = this.client.getConnectionManager().establishedConnections;
+        for (var address in estConnections) {
+            if ( estConnections.hasOwnProperty(address)) {
+                var conn = estConnections[address];
+                var timeSinceLastRead = new Date().getTime() - conn.lastRead;
+                if (timeSinceLastRead > this.heartbeatTimeout) {
+                    if (conn.heartbeating) {
+                        process.nextTick(this.onHeartbeatStopped.bind(this, conn));
+                    }
+                }
+                if (timeSinceLastRead > this.heartbeatInterval) {
+                    var req = ClientPingCodec.encodeRequest();
+                    this.client.getInvocationService().invokeOnConnection(conn, req);
+                } else {
+                    if (!conn.heartbeating) {
+                        process.nextTick(this.onHeartbeatRestored.bind(this, conn));
+                    }
+                }
+            }
+        }
+        this.timer = setTimeout(this.heartbeatFunction.bind(this), this.heartbeatInterval);
+    }
+
+    private onHeartbeatStopped(connection: ClientConnection) {
+        connection.heartbeating = false;
+        console.log('heartbeat stopped on ' + connection.address);
+    }
+
+    private onHeartbeatRestored(connection: ClientConnection) {
+        connection.heartbeating = true;
+        console.log('heartbeat restored on ' + connection.address);
+    }
+
+}
+
+export = Heartbeat;

--- a/src/Heartbeat.ts
+++ b/src/Heartbeat.ts
@@ -65,7 +65,7 @@ class Heartbeat {
         console.log('heartbeat stopped on ' + connection.address);
         this.listeners.forEach((listener) => {
             if (listener.hasOwnProperty('onHeartbeatStopped')) {
-                Q.fcall(listener.onHeartbeatStopped.bind(this), connection);
+                setImmediate(listener.onHeartbeatStopped.bind(this), connection);
             }
         });
     }
@@ -75,7 +75,7 @@ class Heartbeat {
         console.log('heartbeat restored on ' + connection.address);
         this.listeners.forEach((listener) => {
             if (listener.hasOwnProperty('onHeartbeatRestored')) {
-                Q.fcall(listener.onHeartbeatRestored.bind(this), connection);
+                setImmediate(listener.onHeartbeatRestored.bind(this), connection);
             }
         });
     }

--- a/src/codec/ClientPingCodec.ts
+++ b/src/codec/ClientPingCodec.ts
@@ -1,0 +1,25 @@
+/* tslint:disable */
+import ClientMessage = require('../ClientMessage');
+var REQUEST_TYPE = 0x000f;
+var RESPONSE_TYPE = 100;
+var RETRYABLE = true;
+
+
+export class ClientPingCodec{
+    static calculateSize(){
+        return 0;
+    }
+
+    static encodeRequest() {
+
+        var clientMessage = ClientMessage.newClientMessage(this.calculateSize());
+        clientMessage.setMessageType(REQUEST_TYPE);
+        clientMessage.setRetryable(RETRYABLE)
+        clientMessage.updateFrameLength();
+        return clientMessage;
+    }
+
+    static decodeResponse(clientMessage: ClientMessage) {
+        return;
+    }
+}

--- a/src/invocation/ClientConnection.ts
+++ b/src/invocation/ClientConnection.ts
@@ -4,13 +4,17 @@ import Address = require('../Address');
 import {BitsUtil} from '../BitsUtil';
 
 class ClientConnection {
-    public address: Address;
-    public socket: net.Socket;
+    address: Address;
+    socket: net.Socket;
+    lastRead: number;
+    heartbeating = true;
+
     private readBuffer: Buffer;
 
     constructor(address: Address) {
         this.address = address;
         this.readBuffer = new Buffer(0);
+        this.lastRead = 0;
     }
 
     public getAddress(): Address {
@@ -44,6 +48,7 @@ class ClientConnection {
 
     registerResponseCallback(callback: Function) {
         this.socket.on('data', (buffer: Buffer) => {
+            this.lastRead = new Date().getTime();
             this.readBuffer = Buffer.concat([this.readBuffer, buffer], this.readBuffer.length + buffer.length);
             while (this.readBuffer.length >= BitsUtil.INT_SIZE_IN_BYTES ) {
                 var frameSize = this.readBuffer.readInt32LE(0);

--- a/src/invocation/ClientConnection.ts
+++ b/src/invocation/ClientConnection.ts
@@ -17,7 +17,7 @@ class ClientConnection {
         this.lastRead = 0;
     }
 
-    public getAddress(): Address {
+    getAddress(): Address {
         return this.address;
     }
 
@@ -25,7 +25,6 @@ class ClientConnection {
         var ready = Q.defer<ClientConnection>();
 
         this.socket = net.connect(this.address.port, this.address.host, () => {
-            console.log('Connection established to ' + this.address );
 
             // Send the protocol version
             var buffer = new Buffer(3);
@@ -44,6 +43,10 @@ class ClientConnection {
 
     write(buffer: Buffer) {
         this.socket.write(buffer);
+    }
+
+    close() {
+        this.socket.destroy();
     }
 
     registerResponseCallback(callback: Function) {

--- a/src/invocation/ClientConnectionManager.ts
+++ b/src/invocation/ClientConnectionManager.ts
@@ -15,7 +15,7 @@ class ClientConnectionManager {
     private client: HazelcastClient;
 
     private pendingConnections: {[address: string]: Q.Deferred<ClientConnection>} = {};
-    private establishedConnections: {[address: string]: ClientConnection} = {};
+    establishedConnections: {[address: string]: ClientConnection} = {};
 
     constructor(client: HazelcastClient) {
         this.client = client;

--- a/src/invocation/ClientConnectionManager.ts
+++ b/src/invocation/ClientConnectionManager.ts
@@ -9,11 +9,12 @@ import {GroupConfig, ClientNetworkConfig} from '../Config';
 
 import ConnectionAuthenticator = require('./ConnectionAuthenticator');
 import HazelcastClient = require('../HazelcastClient');
+import {ConnectionListener} from '../ConnectionListener';
 
 class ClientConnectionManager {
 
     private client: HazelcastClient;
-
+    private listeners: ConnectionListener[] = [];
     private pendingConnections: {[address: string]: Q.Deferred<ClientConnection>} = {};
     establishedConnections: {[address: string]: ClientConnection} = {};
 
@@ -21,7 +22,7 @@ class ClientConnectionManager {
         this.client = client;
     }
 
-    public getOrConnect(address: Address): Q.Promise<ClientConnection> {
+    getOrConnect(address: Address): Q.Promise<ClientConnection> {
         var addressIndex = address.toString();
         var result: Q.Deferred<ClientConnection> = Q.defer<ClientConnection>();
 
@@ -43,7 +44,6 @@ class ClientConnectionManager {
         var clientConnection = new ClientConnection(address);
 
         clientConnection.connect().then((connection: ClientConnection) => {
-
             connection.registerResponseCallback((data: Buffer) => {
                 this.client.getInvocationService().processResponse(data);
             });
@@ -51,13 +51,16 @@ class ClientConnectionManager {
             var callback = (authenticated: boolean) => {
                 if (authenticated) {
                     result.resolve(connection);
-                    this.establishedConnections[addressIndex] = connection;
+                    this.establishedConnections[connection.address.toString()] = connection;
                 } else {
                     result.reject(new Error('Authentication failed'));
                 }
             };
-
-            this.authenticate(connection).then(callback).finally(() => {
+            this.authenticate(connection).then(callback).then(() => {
+                this.onConnectionOpened(connection);
+            }).catch((e: any) => {
+                result.reject(e);
+            }).finally(() => {
                 delete this.pendingConnections[addressIndex];
             });
         }).catch((e: any) => {
@@ -65,6 +68,40 @@ class ClientConnectionManager {
         });
 
         return result.promise;
+    }
+
+    destroyConnection(address: Address): void {
+        var addressStr = address.toString();
+        if (this.pendingConnections.hasOwnProperty(addressStr)) {
+            this.pendingConnections[addressStr].reject(null);
+        }
+        if (this.establishedConnections.hasOwnProperty(addressStr)) {
+            var conn = this.establishedConnections[addressStr];
+            conn.close();
+            this.onConnectionClosed(conn);
+            delete this.establishedConnections[addressStr];
+        }
+    }
+
+    addListener(listener: ConnectionListener) {
+        this.listeners.push(listener);
+    }
+
+    private onConnectionClosed(connection: ClientConnection) {
+        this.listeners.forEach((listener) => {
+            if (listener.hasOwnProperty('onConnectionClosed')) {
+                setImmediate(listener.onConnectionClosed.bind(this), connection);
+            }
+        });
+    }
+
+    private onConnectionOpened(connection: ClientConnection) {
+        console.log('Authenticated to ' + connection.address);
+        this.listeners.forEach((listener) => {
+            if (listener.hasOwnProperty('onConnectionOpened')) {
+                setImmediate(listener.onConnectionOpened.bind(this), connection);
+            }
+        });
     }
 
     private authenticate(connection: ClientConnection): Q.Promise<boolean> {

--- a/src/invocation/InvocationService.ts
+++ b/src/invocation/InvocationService.ts
@@ -113,6 +113,7 @@ export class InvocationService {
         var pending = this.pending[correlationId].deferred;
         if (messageType === InvocationService.EXCEPTION_MESSAGE_TYPE) {
             var remoteException = ExceptionCodec.decodeResponse(clientMessage);
+            console.log(remoteException);
             pending.reject(remoteException);
         } else {
             pending.resolve(clientMessage);


### PR DESCRIPTION
Implements Heartbeat mechanism.
Adds options for `hazelcast.client.heartbeat.interval` and `hazelcast.client.heartbeat.timeout` to config.
Detects unresponsive nodes based on Heartbeat but doesn't do anything about it.